### PR TITLE
Lfs fixes

### DIFF
--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -102,15 +102,11 @@ public class Commit implements Markable {
 			return;
 		}
 		if (null != filesAttributes) {
-			try {
-				//.gitattributes file generation
-				Data attributeFile = new Data();
-				attributeFile.writeData(filesAttributes.toString().getBytes("UTF-8"));
-				FastImportFile attributes = new FastImportFile(out, attributeFile, ".gitattributes");
-				this.addFileOperation(attributes);
-
-			} catch (InvalidPathException ex) {
-			}
+			//.gitattributes file generation
+			Data attributeFile = new Data();
+			attributeFile.writeData(filesAttributes.toString().getBytes("UTF-8"));
+			FastImportFile attributes = new FastImportFile(out, attributeFile, ".gitattributes");
+			this.addFileOperation(attributes.getModification());
 		}
 
 		if (null != lfsConfigUrl) {

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.ossnoize.git.fastimport.enumeration.File;
 import org.ossnoize.git.fastimport.enumeration.GitFileType;
 import org.ossnoize.git.fastimport.exception.InvalidPathException;
 
@@ -123,21 +124,17 @@ public class Commit implements Markable {
 			}
 		}
 
-		Set<String> listOfTrackedFiles = repositoryHelper.getListOfTrackedFile(reference);
-		if (null != lfsConfigUrl && !listOfTrackedFiles.contains(".lfsconfig")) {
+		if (null != lfsConfigUrl)) {
 			try {
 				//.lfsconfig file generation
-				Data lfsconfigFile = new Data();
+				Data lfsconfigData = new Data();
 				String lfsString = "[lfs]\n";
 				lfsconfigFile.writeData(lfsString.getBytes("UTF-8"));
 				String urlString = "    url = " + lfsConfigUrl;
 				lfsconfigFile.writeData(urlString.getBytes("UTF-8"));
-				Blob aLfsMarkedBlob = new Blob(lfsconfigFile);
-				aLfsMarkedBlob.writeTo(out);
-				FileModification lfsconfig = new FileModification(aLfsMarkedBlob);
-				lfsconfig.setFileType(GitFileType.Normal);
-				lfsconfig.setPath(".lfsconfig");
-				this.addFileOperation(lfsconfig);
+				File lfsconfigFile = new File(out, lfsconfigData, ".lfsconfig");
+				this.addFileOperation(lfsconfigFile.getModification());
+
 			} catch (InvalidPathException ex) {
 			}
 		}

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -131,7 +131,7 @@ public class Commit implements Markable {
 				lfsconfigFile.writeData(lfsString.getBytes("UTF-8"));
 				String urlString = "    url = " + lfsConfigUrl;
 				lfsconfigFile.writeData(urlString.getBytes("UTF-8"));
-				File lfsconfigFile = new File(out, lfsconfigData, ".lfsconfig");
+				FastImportFile lfsconfigFile = new FastImportFile(out, lfsconfigData, ".lfsconfig");
 				this.addFileOperation(lfsconfigFile.getModification());
 
 			} catch (InvalidPathException ex) {

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -128,9 +128,9 @@ public class Commit implements Markable {
 				//.lfsconfig file generation
 				Data lfsconfigData = new Data();
 				String lfsString = "[lfs]\n";
-				lfsconfigFile.writeData(lfsString.getBytes("UTF-8"));
+				lfsconfigData.writeData(lfsString.getBytes("UTF-8"));
 				String urlString = "    url = " + lfsConfigUrl;
-				lfsconfigFile.writeData(urlString.getBytes("UTF-8"));
+				lfsconfigData.writeData(urlString.getBytes("UTF-8"));
 				FastImportFile lfsconfigFile = new FastImportFile(out, lfsconfigData, ".lfsconfig");
 				this.addFileOperation(lfsconfigFile.getModification());
 

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -106,11 +106,7 @@ public class Commit implements Markable {
 				//.gitattributes file generation
 				Data attributeFile = new Data();
 				attributeFile.writeData(filesAttributes.toString().getBytes("UTF-8"));
-				Blob aMarkedBlob = new Blob(attributeFile);
-				aMarkedBlob.writeTo(out);
-				FileModification attributes = new FileModification(aMarkedBlob);
-				attributes.setFileType(GitFileType.Normal);
-				attributes.setPath(".gitattributes");
+				FastImportFile attributes = new FastImportFile(out, attributeFile, ".gitattributes");
 				this.addFileOperation(attributes);
 
 			} catch (InvalidPathException ex) {

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -124,7 +124,7 @@ public class Commit implements Markable {
 			}
 		}
 
-		if (null != lfsConfigUrl)) {
+		if (null != lfsConfigUrl) {
 			try {
 				//.lfsconfig file generation
 				Data lfsconfigData = new Data();

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.ossnoize.git.fastimport.File;
+import org.ossnoize.git.fastimport.FastImportFile;
 import org.ossnoize.git.fastimport.enumeration.GitFileType;
 import org.ossnoize.git.fastimport.exception.InvalidPathException;
 

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.ossnoize.git.fastimport.enumeration.File;
+import org.ossnoize.git.fastimport.File;
 import org.ossnoize.git.fastimport.enumeration.GitFileType;
 import org.ossnoize.git.fastimport.exception.InvalidPathException;
 

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -118,18 +118,14 @@ public class Commit implements Markable {
 		}
 
 		if (null != lfsConfigUrl) {
-			try {
-				//.lfsconfig file generation
-				Data lfsconfigData = new Data();
-				String lfsString = "[lfs]\n";
-				lfsconfigData.writeData(lfsString.getBytes("UTF-8"));
-				String urlString = "    url = " + lfsConfigUrl;
-				lfsconfigData.writeData(urlString.getBytes("UTF-8"));
-				FastImportFile lfsconfigFile = new FastImportFile(out, lfsconfigData, ".lfsconfig");
-				this.addFileOperation(lfsconfigFile.getModification());
-
-			} catch (InvalidPathException ex) {
-			}
+			//.lfsconfig file generation
+			Data lfsconfigData = new Data();
+			String lfsString = "[lfs]\n";
+			lfsconfigData.writeData(lfsString.getBytes("UTF-8"));
+			String urlString = "    url = " + lfsConfigUrl;
+			lfsconfigData.writeData(urlString.getBytes("UTF-8"));
+			FastImportFile lfsconfigFile = new FastImportFile(out, lfsconfigData, ".lfsconfig");
+			this.addFileOperation(lfsconfigFile.getModification());
 		}
 		StringBuilder commitMsg = new StringBuilder();
 		commitMsg.append(COMMIT).append(" ").append(MessageFormat.format(headFormat, reference, "")).append('\n');

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -42,7 +42,6 @@ public class Commit implements Markable {
 	private boolean written;
 	private GitAttributes filesAttributes;
 	private String lfsConfigUrl;
-	private RepositoryHelper repositoryHelper;
 
 	public Commit(String name, String email, String message, String reference, java.util.Date commitDate) throws IOException {
 		if(null == message) {
@@ -57,7 +56,6 @@ public class Commit implements Markable {
 		listOfOperation = new TreeMap<String, FileOperation>();
 		filesAttributes = null;
 		lfsConfigUrl = null;
-        repositoryHelper = RepositoryHelperFactory.getFactory().createHelper();
 	}
 
 	public void setAuthor(String name, String email) {

--- a/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/Commit.java
@@ -16,10 +16,6 @@ import org.ossnoize.git.fastimport.FastImportFile;
 import org.ossnoize.git.fastimport.enumeration.GitFileType;
 import org.ossnoize.git.fastimport.exception.InvalidPathException;
 
-import org.sync.githelper.GitHelper;
-import org.sync.RepositoryHelper;
-import org.sync.RepositoryHelperFactory;
-
 public class Commit implements Markable {
 	private final static String COMMIT = "commit";
 	private final static String AUTHOR = "author";

--- a/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
@@ -1,6 +1,7 @@
 package org.ossnoize.git.fastimport;
 
 import org.ossnoize.git.fastimport.enumeration.GitFileType;
+import org.ossnoize.git.fastimport.exception.InvalidPathException;
 import java.io.OutputStream;
 
 public class FastImportFile

--- a/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
@@ -18,14 +18,21 @@ public class FastImportFile
             modification = new FileModification(blob);
             modification.setFileType(GitFileType.Normal);
             modification.setPath(fileName);
-        } catch (InvalidPathException ex) {}
+        } catch (InvalidPathException ex) {
+        } catch (IOException e){
+            e.printStackTrace();
+        }
     }
 
-    public FastImportFile(OutputStream out, Data fileData, Blob fileBlob, FileModification fileModification){
-        data = fileData;
-        blob = fileBlob;
-        blob.writeTo(out);
-        modification = fileModification;
+    public FastImportFile(OutputStream out, Data fileData, Blob fileBlob, FileModification fileModification) {
+        try{
+            data = fileData;
+            blob = fileBlob;
+            blob.writeTo(out);
+            modification = fileModification;
+        } catch (IOException e){
+            e.printStackTrace();
+      }
     }
 
     public Blob getBlob(){

--- a/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
@@ -10,12 +10,14 @@ public class FastImportFile
     private FileModification modification;
 
     public FastImportFile(OutputStream out, Data filedata, String fileName){
-        data = filedata;
-        blob = new Blob(filedata);
-        blob.writeTo(out);
-        modification = new FileModification(blob);
-        modification.setFileType(GitFileType.Normal);
-        modification.setPath(fileName);
+        try {
+            data = filedata;
+            blob = new Blob(filedata);
+            blob.writeTo(out);
+            modification = new FileModification(blob);
+            modification.setFileType(GitFileType.Normal);
+            modification.setPath(fileName);
+        } catch (InvalidPathException ex) {}
     }
 
     public FastImportFile(OutputStream out, Data fileData, Blob fileBlob, FileModification fileModification){

--- a/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
@@ -3,13 +3,13 @@ package org.ossnoize.git.fastimport;
 import org.ossnoize.git.fastimport.enumeration.GitFileType;
 import java.io.OutputStream;
 
-public class File
+public class FastImportFile
 {
     private Blob blob;
     private Data data;
     private FileModification modification;
 
-    public File(OutputStream out, Data filedata, String fileName){
+    public FastImportFile(OutputStream out, Data filedata, String fileName){
         data = filedata;
         blob = new Blob(filedata);
         blob.writeTo(out);
@@ -18,7 +18,7 @@ public class File
         modification.setPath(fileName);
     }
 
-    public File(OutputStream out, Data fileData, Blob fileBlob, FileModification fileModification){
+    public FastImportFile(OutputStream out, Data fileData, Blob fileBlob, FileModification fileModification){
         data = fileData;
         blob = fileBlob;
         blob.writeTo(out);

--- a/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/FastImportFile.java
@@ -1,5 +1,7 @@
 package org.ossnoize.git.fastimport;
 
+import java.io.IOException;
+
 import org.ossnoize.git.fastimport.enumeration.GitFileType;
 import org.ossnoize.git.fastimport.exception.InvalidPathException;
 import java.io.OutputStream;

--- a/syncronizer/src/org/ossnoize/git/fastimport/File.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/File.java
@@ -1,5 +1,7 @@
 package org.ossnoize.git.fastimport;
 
+import java.io.OutputStream;
+
 public class File
 {
     private Blob blob;

--- a/syncronizer/src/org/ossnoize/git/fastimport/File.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/File.java
@@ -1,5 +1,6 @@
 package org.ossnoize.git.fastimport;
 
+import org.ossnoize.git.fastimport.enumeration.GitFileType;
 import java.io.OutputStream;
 
 public class File
@@ -14,7 +15,7 @@ public class File
         blob.writeTo(out);
         modification = new FileModification(blob);
         modification.setFileType(GitFileType.Normal);
-        modification.setPath(filename);
+        modification.setPath(fileName);
     }
 
     public File(OutputStream out, Data fileData, Blob fileBlob, FileModification fileModification){

--- a/syncronizer/src/org/ossnoize/git/fastimport/File.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/File.java
@@ -1,0 +1,36 @@
+package org.ossnoize.git.fastimport;
+
+public class File
+{
+    private Blob blob;
+    private Data data;
+    private FileModification modification;
+
+    public File(OutputStream out, Data filedata, String fileName){
+        data = filedata;
+        blob = new Blob(filedata);
+        blob.writeTo(out);
+        modification = new FileModification(blob);
+        modification.setFileType(GitFileType.Normal);
+        modification.setPath(filename);
+    }
+
+    public File(OutputStream out, Data fileData, Blob fileBlob; FileModification fileModification){
+        data = fileData;
+        blob = fileBlob;
+        blob.writeTo(out);
+        modification = fileModification;
+    }
+
+    public Blob getBlob(){
+        return blob;
+    }
+
+    public Data getData(){
+        return data;
+    }
+
+    public FileModification getModification() {
+        return modification;
+    }
+}

--- a/syncronizer/src/org/ossnoize/git/fastimport/File.java
+++ b/syncronizer/src/org/ossnoize/git/fastimport/File.java
@@ -15,7 +15,7 @@ public class File
         modification.setPath(filename);
     }
 
-    public File(OutputStream out, Data fileData, Blob fileBlob; FileModification fileModification){
+    public File(OutputStream out, Data fileData, Blob fileBlob, FileModification fileModification){
         data = fileData;
         blob = fileBlob;
         blob.writeTo(out);

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -377,10 +377,6 @@ public class GitImporter {
 						lastCommit.setAttributes(fattributes);
 					}
 				} else {
-					if(isFirstCommit && lfsConfigUrl != null){
-						commit.setLfsConfigUrl(lfsConfigUrl);
-						isFirstCommit=false;
-					}
 					java.util.Date commitDate = new java.util.Date(current.getTime());
 					// validate that the last commit done wasn't newer than the commit we will be doing
 					if (null != lastCommit && lastCommit.getCommitDate().getTime() >= current.getTime()) {
@@ -394,7 +390,10 @@ public class GitImporter {
 					if (fattributes != null) {
 						commit.setAttributes(fattributes);
 					}
-
+					if(lfsConfigUrl != null && isFirstCommit){
+						commit.setLfsConfigUrl(lfsConfigUrl);
+						isFirstCommit=false;
+					}
 					if(null == lastCommit) {
 						if(isResume) {
 							commit.resumeOnTopOfRef();

--- a/syncronizer/src/org/sync/GitImporter.java
+++ b/syncronizer/src/org/sync/GitImporter.java
@@ -78,7 +78,8 @@ public class GitImporter {
 	private Server server;
 	private Folder folder;
 	private long lastModifiedTime = 0;
-	private Commit lastCommit; 
+	private Commit lastCommit;
+	private boolean isFirstCommit = true;
 	// get the really old time as base information;
 	private CommitInformation lastInformation = null;
 	private String alternateHead = null;
@@ -375,10 +376,11 @@ public class GitImporter {
 					if (fattributes != null) {
 						lastCommit.setAttributes(fattributes);
 					}
-					if(lfsConfigUrl != null){
-						lastCommit.setLfsConfigUrl(lfsConfigUrl);
-					}
 				} else {
+					if(isFirstCommit && lfsConfigUrl != null){
+						commit.setLfsConfigUrl(lfsConfigUrl);
+						isFirstCommit=false;
+					}
 					java.util.Date commitDate = new java.util.Date(current.getTime());
 					// validate that the last commit done wasn't newer than the commit we will be doing
 					if (null != lastCommit && lastCommit.getCommitDate().getTime() >= current.getTime()) {
@@ -392,9 +394,7 @@ public class GitImporter {
 					if (fattributes != null) {
 						commit.setAttributes(fattributes);
 					}
-					if(lfsConfigUrl != null){
-						commit.setLfsConfigUrl(lfsConfigUrl);
-					}
+
 					if(null == lastCommit) {
 						if(isResume) {
 							commit.resumeOnTopOfRef();

--- a/syncronizer/src/org/sync/MainEntry.java
+++ b/syncronizer/src/org/sync/MainEntry.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.sync.commitstrategy.BasePopulationStrategy;
 import org.sync.commitstrategy.ChangeRequestPopulationStrategy;
 import org.sync.commitstrategy.RevisionPopulationStrategy;
+import org.sync.RepositoryHelperFactory;
 
 import com.starbase.starteam.ClientApplication;
 import com.starbase.starteam.Project;

--- a/syncronizer/src/org/sync/MainEntry.java
+++ b/syncronizer/src/org/sync/MainEntry.java
@@ -145,6 +145,7 @@ public class MainEntry {
         String lfsSize = (String) parser.getOptionValue(trackAsLfsFromSize);
         String lfsPattern = (String) parser.getOptionValue(trackAsLfsPattern);
         String lfsConfigUrl = (String) parser.getOptionValue(selectLfsConfigUrl);
+		RepositoryHelper repositoryHelper = RepositoryHelperFactory.getFactory().createHelper();
 
 		@SuppressWarnings("rawtypes")
 		Vector excludedLabels = parser.getOptionValues(excludeLabel);

--- a/syncronizer/src/org/sync/MainEntry.java
+++ b/syncronizer/src/org/sync/MainEntry.java
@@ -288,7 +288,8 @@ public class MainEntry {
 						if(null != dumpTo) {
 							importer.setDumpFile(new File(dumpTo));
 						}
-						if(lfsConfigUrl != null){
+						Set<String> listOfTrackedFiles = repositoryHelper.getListOfTrackedFile(head);
+						if (null != lfsConfigUrl && !listOfTrackedFiles.contains(".lfsconfig")) {
 							importer.setLFSConfigUrl(lfsConfigUrl);
 						}
 						importer.setVerbose(verbose);

--- a/syncronizer/src/org/sync/MainEntry.java
+++ b/syncronizer/src/org/sync/MainEntry.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Vector;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.Set;
 
 import org.sync.commitstrategy.BasePopulationStrategy;
 import org.sync.commitstrategy.ChangeRequestPopulationStrategy;

--- a/syncronizer/src/org/sync/MainEntry.java
+++ b/syncronizer/src/org/sync/MainEntry.java
@@ -32,6 +32,8 @@ import java.util.Set;
 import org.sync.commitstrategy.BasePopulationStrategy;
 import org.sync.commitstrategy.ChangeRequestPopulationStrategy;
 import org.sync.commitstrategy.RevisionPopulationStrategy;
+import org.sync.githelper.GitHelper;
+import org.sync.RepositoryHelper;
 import org.sync.RepositoryHelperFactory;
 
 import com.starbase.starteam.ClientApplication;


### PR DESCRIPTION
Changes made for [Pull-request 65](https://github.com/planestraveler/git-starteam/pull/65)

- [x] Addition of an actual Object managing the .lfsconfig file. Enabling further extension afterward in the same spirit as the .gitattribute

- [x] Do not add the .lfsconfig to each commit. This isn't really desirable for everyone.

- [x] Change the place to check if the .lfsconfig file already exist. The commit object should only take care of committing files and nothing else.

- [x] For now, if the .lfsconfig file already exist in the repository. We keep it as is.